### PR TITLE
Fix Dramatic Shape HUD overlays and mapped controller input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- XP bar and caught Pokémon indicator now follow the moved HUD panels in
+  Dramatic Shape Voxel Mod's 3D battle mode.
+- Mapped controllers no longer receive duplicate raw joystick bindings that
+  could turn shoulder buttons into START or make START/Plus stop responding.
+
 ## v1.2.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ After installing, features default to **OFF**.
 <figure>
   <figcaption>
     <em>
-      XP bar and caught Pokémon indicator (Gen2 style), supports normal and wide battle modes
+      XP bar and caught Pokémon indicator (Gen2 style), supports normal, wide,
+      and Dramatic Shape 3D battle modes
     </em>
   </figcaption>
   <img src="images/battle.gif">

--- a/main.lua
+++ b/main.lua
@@ -23,6 +23,7 @@ return function(mod)
     loadModule("qol_feature_easy_interactions.lua"),
     loadModule("qol_feature_location_banners.lua"),
   }
+  loadModule("qol_controller_compat.lua").install()
   local services = {
     options = loadModule("qol_options.lua").install(mod, features),
     battle = loadModule("qol_battle_overlays.lua").new(mod),

--- a/qol_battle_overlays.lua
+++ b/qol_battle_overlays.lua
@@ -1,5 +1,39 @@
 local M = {}
 
+-- Dramatic Shape's 3D-BTL path moves the classic HUD bands out of the
+-- 160x144 battle canvas and composites them into a full-window canvas.  Its
+-- live shot exposes the exact window transform.  Join that canvas when it is
+-- present; returning false keeps every other renderer on the normal path.
+local function drawSnappedHud(battle, side, draw)
+  local shot = battle and battle.dramaticShapeShot
+  if type(shot) ~= "table" or shot.canvas == nil then return false end
+  local pw, ly, scale = tonumber(shot.pw), tonumber(shot.ly),
+                        tonumber(shot.scale)
+  if not pw or not ly or not scale or pw <= 0 or scale <= 0 then return false end
+
+  local originX
+  if side == "player" then
+    -- The whole 160px player band is snapped so its right edge touches the
+    -- window's right edge.
+    originX = pw - 160 * scale
+  elseif side == "enemy" then
+    -- The enemy panel starts at classic x=8 and is snapped to the left edge.
+    originX = -8 * scale
+  else
+    return false
+  end
+
+  local g = love.graphics
+  local priorCanvas = g.getCanvas()
+  local ok, err = pcall(function()
+    g.setCanvas(shot.canvas)
+    draw(originX, ly, scale)
+  end)
+  if priorCanvas then g.setCanvas(priorCanvas) else g.setCanvas() end
+  if not ok then error(err, 0) end
+  return true
+end
+
 function M.new(mod)
   local overlays = {}
   local wrapped = setmetatable({}, { __mode = "k" })
@@ -41,6 +75,9 @@ function M.new(mod)
           sx = sx,
           sy = sy,
           slide = (self.introSlide or 0) * 4,
+          drawSnappedHud = function(side, draw)
+            return drawSnappedHud(self, side, draw)
+          end,
         }
 
         for i, overlay in ipairs(overlays) do

--- a/qol_controller_compat.lua
+++ b/qol_controller_compat.lua
@@ -1,0 +1,39 @@
+local M = {}
+
+local RAW_METHODS = {
+  "joystickpressed",
+  "joystickreleased",
+  "joystickaxis",
+  "joystickhat",
+}
+
+local function isMappedGamepad(joystick)
+  return joystick
+     and type(joystick.isGamepad) == "function"
+     and joystick:isGamepad()
+end
+
+function M.install()
+  local Input = require("src.core.Input")
+  if rawget(Input, "__qolMappedGamepadGuard") then return end
+
+  -- Gen1Recomp 0.1.41 added raw joystick fallbacks for handheld controls.
+  -- LÖVE also sends those raw callbacks for controllers that already have
+  -- an SDL gamepad mapping, so the same physical press can acquire a second,
+  -- device-specific meaning (Switch Plus: START + raw SELECT; L: raw START).
+  -- Keep the fallback for genuinely unmapped joysticks and let mapped pads
+  -- use the standardized gamepad callbacks exclusively.
+  for _, name in ipairs(RAW_METHODS) do
+    local original = Input[name]
+    if type(original) == "function" then
+      Input[name] = function(self, joystick, ...)
+        if isMappedGamepad(joystick) then return end
+        return original(self, joystick, ...)
+      end
+    end
+  end
+
+  rawset(Input, "__qolMappedGamepadGuard", true)
+end
+
+return M

--- a/qol_feature_caught_indicator.lua
+++ b/qol_feature_caught_indicator.lua
@@ -57,18 +57,28 @@ function feature.install(mod, services)
        or not enemyHudVisible(battle, context.slide) then return end
     local image, quad = ballAsset()
     if not image then return end
-    local x, y
-    if battle:wideLayout() then
-      x, y = 112, 7
-    else
-      local hudShake = battle.fx and battle.fx.hudShakeX or 0
-      x, y = 7 + context.sx + hudShake, 7 + context.sy
-    end
+    local hudShake = battle.fx and battle.fx.hudShakeX or 0
+    local classicX = 7 + context.sx + hudShake
+    local classicY = 7 + context.sy
     love.graphics.setShader()
     if mode == "red" then
       love.graphics.setColor(1, 0, 0, 1)
     else
       love.graphics.setColor(1, 1, 1, 1)
+    end
+    if context.drawSnappedHud
+       and context.drawSnappedHud("enemy", function(originX, originY, scale)
+         love.graphics.draw(image, quad,
+           originX + classicX * scale, originY + classicY * scale,
+           0, scale, scale)
+       end) then
+      return
+    end
+    local x, y
+    if battle:wideLayout() then
+      x, y = 112, 7
+    else
+      x, y = classicX, classicY
     end
     love.graphics.draw(image, quad, x, y)
     PaletteFX.markTrueColor(x, y, 8, 8)

--- a/qol_feature_easy_interactions.lua
+++ b/qol_feature_easy_interactions.lua
@@ -158,9 +158,12 @@ function feature.install(mod, services)
       local game = mod.world.game
       if not enabled(game) or not game or not game.stack
          or game.stack:top() ~= ow then return false end
+      -- Some Gen1Recomp builds report one mapped controller press through
+      -- both gamepad and raw-joystick callbacks. START must retain priority
+      -- if that produces a spurious SELECT edge at the same time.
+      if game.input:wasPressed("start") then return false end
       if not game.input:wasPressed("select") then return false end
-      openSelectFieldMoves(ow)
-      return true
+      return openSelectFieldMoves(ow)
     end
   end
 

--- a/qol_feature_xp_bar.lua
+++ b/qol_feature_xp_bar.lua
@@ -189,6 +189,21 @@ function feature.install(mod, services)
     if not battle.player or battle.safari or battle.demo
        or battle.showPlayerBack or context.slide ~= 0 then return end
     local px = animatedExpPixels(battle, state)
+    if px > 0 and context.drawSnappedHud
+       and context.drawSnappedHud("player", function(originX, originY, scale)
+         -- 3D-BTL has already moved the classic player HUD into the window
+         -- canvas.  Draw the fill into that same canvas with the identical
+         -- classic-to-window transform instead of leaving it behind in the
+         -- centered 160x144 battle surface.
+         local x = originX + (EXP_X + EXP_WIDTH - px + context.sx) * scale
+         local y = originY + (EXP_Y + context.sy) * scale
+         local color = mode == "black" and EXP_BLACK or EXP_BLUE
+         love.graphics.setShader()
+         love.graphics.setColor(color[1], color[2], color[3], color[4])
+         love.graphics.rectangle("fill", x, y, px * scale, 2 * scale)
+       end) then
+      return
+    end
     if battle:wideLayout() then
       drawWideExpBar(px, mode)
       return

--- a/tests/quality_of_life_test.lua
+++ b/tests/quality_of_life_test.lua
@@ -9,6 +9,32 @@ Data:load()
 local Font = require("src.render.Font")
 Font.load(Data)
 
+-- Give the mod's overworld-input wrapper a minimal base handler. This keeps
+-- the feature tests focused on whether QoL consumes an edge or passes it on,
+-- without constructing a complete live OverworldState.
+local OverworldController = require("src.world.OverworldController")
+local originalOverworldHandleInput = OverworldController.handleInput
+local baseInputCalls = 0
+OverworldController.handleInput = function()
+  baseInputCalls = baseInputCalls + 1
+end
+
+-- Recreate Gen1Recomp 0.1.41-0.1.54's raw-input behavior even when these
+-- tests run against an engine checkout that already contains the upstream
+-- guard. The mod must remain independently capable of protecting released
+-- builds that users already have installed.
+local EngineInput = require("src.core.Input")
+local rawInputMethods = {}
+for _, name in ipairs({
+  "joystickpressed", "joystickreleased", "joystickaxis", "joystickhat",
+}) do
+  local original = EngineInput[name]
+  rawInputMethods[name] = original
+  EngineInput[name] = function(self, _, ...)
+    return original(self, nil, ...)
+  end
+end
+
 local function read(path)
   local file = assert(io.open(path, "rb"))
   local source = file:read("*a")
@@ -21,6 +47,7 @@ for _, name in ipairs({
   "manifest.json",
   "main.lua",
   "qol_options.lua",
+  "qol_controller_compat.lua",
   "qol_battle_overlays.lua",
   "qol_feature_xp_bar.lua",
   "qol_feature_caught_indicator.lua",
@@ -37,6 +64,30 @@ T.eq(#run.errors, 0, "loads clean (" .. tostring(run.errors[1]) .. ")")
 local exports = run.loader.exports.quality_of_life
 T.check(exports and exports.screenId == "QualityOfLife",
   "exports the submenu screen id")
+
+-- Gen1Recomp 0.1.41+ sends raw joystick callbacks alongside standardized
+-- gamepad callbacks. A mapped Switch controller reports Plus as gamepad
+-- START and raw button 7; the engine's generic fallback otherwise adds
+-- SELECT, while raw button 10 turns L into START.
+local mappedPad = { isGamepad = function() return true end }
+EngineInput:init()
+EngineInput:gamepadpressed(mappedPad, "start")
+EngineInput:joystickpressed(mappedPad, 7)
+EngineInput:step()
+T.check(EngineInput:wasPressed("start")
+        and not EngineInput:wasPressed("select"),
+  "mapped controller Plus remains START without a duplicate raw SELECT")
+EngineInput:reset()
+EngineInput:joystickpressed(mappedPad, 10)
+EngineInput:step()
+T.check(not EngineInput:wasPressed("start"),
+  "mapped controller shoulder buttons do not become raw START")
+local rawPad = { isGamepad = function() return false end }
+EngineInput:reset()
+EngineInput:joystickpressed(rawPad, 10)
+EngineInput:step()
+T.check(EngineInput:wasPressed("start"),
+  "unmapped joystick fallback keeps its raw START binding")
 
 local loadChunk = loadstring or load
 local transform = assert(loadChunk(modFiles[
@@ -369,8 +420,14 @@ game.save.inventory.OLD_ROD = nil
 game.save.inventory.GOOD_ROD = nil
 game.save.inventory.SUPER_ROD = nil
 
-local OverworldController = require("src.world.OverworldController")
 local oldScreensPush = Screens.push
+local beforeStart = baseInputCalls
+input.pressed = { start = true, select = true }
+OverworldController.handleInput(overworld)
+input.pressed = {}
+T.eq(baseInputCalls, beforeStart + 1,
+  "START reaches the base handler despite a duplicate SELECT edge")
+
 local pushedScreen, pushedOpts
 Screens.push = function(_, id, opts)
   pushedScreen, pushedOpts = id, opts
@@ -531,15 +588,22 @@ local battle = {
 
 local oldDraw, oldRectangle = love.graphics.draw, love.graphics.rectangle
 local ball, bar, draws, rectangles
-love.graphics.draw = function(_, quad, x, y)
+love.graphics.draw = function(_, quad, x, y, _, scaleX, scaleY)
   if y == nil then quad, x, y = nil, quad, x end
   local r, g, b = love.graphics.getColor()
-  ball = { quad = quad, x = x, y = y, color = { r, g, b } }
+  ball = {
+    quad = quad, x = x, y = y, color = { r, g, b },
+    canvas = love.graphics.getCanvas(),
+    scaleX = scaleX or 1, scaleY = scaleY or scaleX or 1,
+  }
   if draws then draws[#draws + 1] = ball end
 end
 love.graphics.rectangle = function(mode, x, y, w, h)
   local r, g, b = love.graphics.getColor()
-  bar = { mode = mode, x = x, y = y, w = w, h = h, color = { r, g, b } }
+  bar = {
+    mode = mode, x = x, y = y, w = w, h = h, color = { r, g, b },
+    canvas = love.graphics.getCanvas(),
+  }
   if rectangles then rectangles[#rectangles + 1] = bar end
 end
 
@@ -565,8 +629,41 @@ T.check(ball and ball.x == 9 and ball.y == 10,
   "caught indicator follows screen shake")
 T.check(ball.color[1] == 1 and ball.color[2] == 0 and ball.color[3] == 0,
   "red indicator mode draws red")
-
 local classicPixels = bar.w
+
+-- Dramatic Shape's 3D-BTL mode snaps the classic HUD bands into a
+-- full-window canvas. Both QoL overlays must follow those bands rather than
+-- remaining in the centered 160x144 battle canvas.
+local voxelCanvas = {}
+local priorCanvas = love.graphics.getCanvas()
+battle.fx = nil
+battle.dramaticShapeShot = {
+  canvas = voxelCanvas, pw = 1920, ly = 108, scale = 6,
+}
+draws, rectangles, bar, ball = {}, {}, nil, nil
+battle:draw()
+local voxelPixels = exports.expPixels(battle)
+T.check(bar and bar.canvas == voxelCanvas,
+  "voxel EXP bar draws into the canvas that owns the snapped player HUD")
+T.eq(bar.x, 1920 - 160 * 6 + (80 + 67 - voxelPixels) * 6,
+  "voxel EXP bar follows the player HUD to the window's right edge")
+T.eq(bar.y, 108 + 89 * 6,
+  "voxel EXP bar stays on the snapped player HUD row")
+T.check(bar.w == voxelPixels * 6 and bar.h == 2 * 6,
+  "voxel EXP bar scales with the snapped HUD")
+T.check(ball and ball.canvas == voxelCanvas,
+  "voxel caught indicator draws into the snapped enemy HUD canvas")
+T.eq(ball.x, -8 * 6 + 7 * 6,
+  "voxel caught indicator follows the enemy HUD to the window's left edge")
+T.eq(ball.y, 108 + 7 * 6,
+  "voxel caught indicator stays on the snapped enemy HUD row")
+T.check(ball.scaleX == 6 and ball.scaleY == 6,
+  "voxel caught indicator scales with the snapped HUD")
+T.eq(love.graphics.getCanvas(), priorCanvas,
+  "voxel overlays restore the battle canvas after drawing")
+battle.dramaticShapeShot = nil
+draws, rectangles = nil, nil
+
 battle.wideLayout = function() return true end
 battle.phase, battle.fx, draws, rectangles = "moveSelect", nil, {}, {}
 game.save.options.modOptions.quality_of_life.qol_exp_bar = "blue"
@@ -679,11 +776,16 @@ game.save.options.modOptions.quality_of_life.qol_exp_bar = "off"
 game.save.options.modOptions.quality_of_life.qol_caught_indicator = "off"
 bar, ball = nil, nil
 battle:draw()
-T.eq(baseDraws, 10, "disabled overlays still call the base renderer")
+T.eq(baseDraws, 11, "disabled overlays still call the base renderer")
 T.check(bar == nil and ball == nil, "disabled options draw no overlays")
 
 love.graphics.draw, love.graphics.rectangle = oldDraw, oldRectangle
 love.graphics.setColor(1, 1, 1, 1)
 run.release()
+for name, original in pairs(rawInputMethods) do
+  EngineInput[name] = original
+end
+rawset(EngineInput, "__qolMappedGamepadGuard", nil)
+OverworldController.handleInput = originalOverworldHandleInput
 Screens.invalidate()
 T.finish("qol later gen")

--- a/tests/voxel_compat_visual.lua
+++ b/tests/voxel_compat_visual.lua
@@ -1,0 +1,64 @@
+-- Visual regression driver for the Dramatic Shape 3D-BTL compatibility.
+-- Run from a gen1recomp checkout with this mod and DRAMATIC_SHAPE linked into
+-- mods/:
+--
+--   SHOT_DIR=/tmp/qol-voxel \
+--   POKEPORT_DRIVER=/path/to/tests/voxel_compat_visual.lua love .
+--
+-- The shot should show the blue EXP bar attached to the player HUD at the
+-- right window edge and the red caught indicator attached to the enemy HUD at
+-- the left edge, with no orphan overlays in the centered Game Boy surface.
+return function(game)
+  local U = dofile("tests/drivers/util.lua")
+  local dir = os.getenv("SHOT_DIR") or "."
+  local Pokemon = require("src.pokemon.Pokemon")
+  local Growth = require("src.pokemon.Growth")
+  local BattleState = require("src.battle.BattleState")
+
+  local exports = game.mods and game.mods.exports
+  local dramatic = exports and exports.DRAMATIC_SHAPE
+  assert(dramatic and dramatic.lib, "DRAMATIC_SHAPE must be enabled")
+  assert(exports and exports.quality_of_life,
+    "quality_of_life must be enabled")
+
+  local battles = dramatic.lib.require("OverworldBattle")
+  battles.setting:setIndex(1, game)
+
+  game.save.options = game.save.options or {}
+  game.save.options.modOptions = game.save.options.modOptions or {}
+  game.save.options.modOptions.quality_of_life = {
+    qol_exp_bar = "blue",
+    qol_caught_indicator = "red",
+  }
+  game.mods.modOptions = game.mods.modOptions or {}
+  game.mods.modOptions.quality_of_life =
+    game.save.options.modOptions.quality_of_life
+
+  local mon = Pokemon.new(game.data, "PIKACHU", 12)
+  local def = game.data.pokemon.PIKACHU
+  local floor = Growth.expForLevel(def.growthRate, mon.level,
+                                   game.data.growth_rates)
+  local ceiling = Growth.expForLevel(def.growthRate, mon.level + 1,
+                                     game.data.growth_rates)
+  mon.exp = math.floor((floor + ceiling) / 2)
+  game.save.party = { mon }
+  game.save.pokedex.owned.PIDGEY = true
+
+  U.teleport(game, "ROUTE_1", 5, 8, "down")
+  U.wait(90)
+
+  local battle = BattleState.newWild(game, "PIDGEY", 3)
+  battle.onFinish = function() end
+  game.overworld:pushBattle(battle)
+
+  U.wait(70)
+  for _ = 1, 200 do
+    if battle.phase == "menu" then break end
+    U.tap(game, "a")
+    U.wait(6)
+  end
+  assert(battle.phase == "menu", "battle did not reach the command menu")
+  U.wait(40)
+  assert(U.shot(game, dir .. "/qol_voxel_compat.png"),
+    "visual regression screenshot was not written")
+end


### PR DESCRIPTION
## Summary

- draw the EXP bar and caught indicator on Dramatic Shape's snapped 3D battle HUD canvas
- ignore duplicate raw joystick callbacks for controllers that already have an SDL gamepad mapping
- preserve START priority if a build reports START and SELECT on the same press
- add automated and visual regression coverage

## Why

This addresses #2 and #8. Gen1Recomp 0.1.41+ added raw joystick fallbacks for unmapped handheld controllers, but LÖVE also reports raw callbacks for mapped gamepads. On a Nintendo Switch Pro Controller, Plus is standardized START plus raw button 7 (which the fallback maps to SELECT), while L is raw button 10 (mapped to START). Easy Interactions could then consume the duplicate SELECT before the base START handler.

## Validation

- `197/197 checks passed (qol later gen)`
- visual Dramatic Shape 1.4.0 battle regression passed: EXP bar attached to the player HUD and caught icon attached to the enemy HUD
- physical Nintendo Switch Pro Controller: Plus remains START; L does not become START
- unmapped joystick fallback remains covered

This is a tested community contribution; please feel free to adjust the implementation to fit the project. Maintainer edits are enabled.

Fixes #2
Fixes #8