### PR TITLE
Fix duplicate mapped controller input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Mapped controllers no longer receive duplicate raw joystick bindings that
+  could turn shoulder buttons into START or make START/Plus stop responding.
+
 ## v1.2.2
 
 ### Tested compatibility

--- a/main.lua
+++ b/main.lua
@@ -23,6 +23,7 @@ return function(mod)
     loadModule("qol_feature_easy_interactions.lua"),
     loadModule("qol_feature_location_banners.lua"),
   }
+  loadModule("qol_controller_compat.lua").install()
   local services = {
     options = loadModule("qol_options.lua").install(mod, features),
     battle = loadModule("qol_battle_overlays.lua").new(mod),

--- a/qol_controller_compat.lua
+++ b/qol_controller_compat.lua
@@ -1,0 +1,39 @@
+local M = {}
+
+local RAW_METHODS = {
+  "joystickpressed",
+  "joystickreleased",
+  "joystickaxis",
+  "joystickhat",
+}
+
+local function isMappedGamepad(joystick)
+  return joystick
+     and type(joystick.isGamepad) == "function"
+     and joystick:isGamepad()
+end
+
+function M.install()
+  local Input = require("src.core.Input")
+  if rawget(Input, "__qolMappedGamepadGuard") then return end
+
+  -- Gen1Recomp 0.1.41 added raw joystick fallbacks for handheld controls.
+  -- LÖVE also sends those raw callbacks for controllers that already have
+  -- an SDL gamepad mapping, so the same physical press can acquire a second,
+  -- device-specific meaning (Switch Plus: START + raw SELECT; L: raw START).
+  -- Keep the fallback for genuinely unmapped joysticks and let mapped pads
+  -- use the standardized gamepad callbacks exclusively.
+  for _, name in ipairs(RAW_METHODS) do
+    local original = Input[name]
+    if type(original) == "function" then
+      Input[name] = function(self, joystick, ...)
+        if isMappedGamepad(joystick) then return end
+        return original(self, joystick, ...)
+      end
+    end
+  end
+
+  rawset(Input, "__qolMappedGamepadGuard", true)
+end
+
+return M

--- a/qol_feature_easy_interactions.lua
+++ b/qol_feature_easy_interactions.lua
@@ -159,9 +159,11 @@ function feature.install(mod, services)
       local game = mod.world.game
       if not enabled(game) or not game or not game.stack
          or game.stack:top() ~= ow then return false end
+      -- START must reach the base handler if one physical controller press
+      -- produced both a standardized START and a duplicate raw SELECT edge.
+      if game.input:wasPressed("start") then return false end
       if not game.input:wasPressed("select") then return false end
-      openSelectFieldMoves(ow)
-      return true
+      return openSelectFieldMoves(ow)
     end
   end
 

--- a/tests/quality_of_life_test.lua
+++ b/tests/quality_of_life_test.lua
@@ -9,6 +9,32 @@ Data:load()
 local Font = require("src.render.Font")
 Font.load(Data)
 
+-- Give the mod's overworld-input wrapper a minimal base handler. This keeps
+-- the feature tests focused on whether QoL consumes an edge or passes it on,
+-- without constructing a complete live OverworldState.
+local OverworldController = require("src.world.OverworldController")
+local originalOverworldHandleInput = OverworldController.handleInput
+local baseInputCalls = 0
+OverworldController.handleInput = function()
+  baseInputCalls = baseInputCalls + 1
+end
+
+-- Recreate Gen1Recomp 0.1.41-0.1.57's raw-input behavior even when these
+-- tests run against an engine checkout that already contains the upstream
+-- guard. The mod must remain independently capable of protecting released
+-- builds that users already have installed.
+local EngineInput = require("src.core.Input")
+local rawInputMethods = {}
+for _, name in ipairs({
+  "joystickpressed", "joystickreleased", "joystickaxis", "joystickhat",
+}) do
+  local original = EngineInput[name]
+  rawInputMethods[name] = original
+  EngineInput[name] = function(self, _, ...)
+    return original(self, nil, ...)
+  end
+end
+
 local function read(path)
   local file = assert(io.open(path, "rb"))
   local source = file:read("*a")
@@ -21,6 +47,7 @@ for _, name in ipairs({
   "manifest.json",
   "main.lua",
   "qol_options.lua",
+  "qol_controller_compat.lua",
   "qol_battle_overlays.lua",
   "qol_feature_xp_bar.lua",
   "qol_feature_caught_indicator.lua",
@@ -37,6 +64,30 @@ T.eq(#run.errors, 0, "loads clean (" .. tostring(run.errors[1]) .. ")")
 local exports = run.loader.exports.quality_of_life
 T.check(exports and exports.screenId == "QualityOfLife",
   "exports the submenu screen id")
+
+-- Gen1Recomp 0.1.41+ sends raw joystick callbacks alongside standardized
+-- gamepad callbacks. A mapped Switch controller reports Plus as gamepad
+-- START and raw button 7; the engine's generic fallback otherwise adds
+-- SELECT, while raw button 10 turns L into START.
+local mappedPad = { isGamepad = function() return true end }
+EngineInput:init()
+EngineInput:gamepadpressed(mappedPad, "start")
+EngineInput:joystickpressed(mappedPad, 7)
+EngineInput:step()
+T.check(EngineInput:wasPressed("start")
+        and not EngineInput:wasPressed("select"),
+  "mapped controller Plus remains START without a duplicate raw SELECT")
+EngineInput:reset()
+EngineInput:joystickpressed(mappedPad, 10)
+EngineInput:step()
+T.check(not EngineInput:wasPressed("start"),
+  "mapped controller shoulder buttons do not become raw START")
+local rawPad = { isGamepad = function() return false end }
+EngineInput:reset()
+EngineInput:joystickpressed(rawPad, 10)
+EngineInput:step()
+T.check(EngineInput:wasPressed("start"),
+  "unmapped joystick fallback keeps its raw START binding")
 
 local loadChunk = loadstring or load
 local transform = assert(loadChunk(modFiles[
@@ -362,8 +413,14 @@ game.save.inventory.OLD_ROD = nil
 game.save.inventory.GOOD_ROD = nil
 game.save.inventory.SUPER_ROD = nil
 
-local OverworldController = require("src.world.OverworldController")
 local oldScreensPush = Screens.push
+local beforeStart = baseInputCalls
+input.pressed = { start = true, select = true }
+OverworldController.handleInput(overworld)
+input.pressed = {}
+T.eq(baseInputCalls, beforeStart + 1,
+  "START reaches the base handler despite a duplicate SELECT edge")
+
 local pushedScreen, pushedOpts
 Screens.push = function(_, id, opts)
   pushedScreen, pushedOpts = id, opts
@@ -718,5 +775,10 @@ T.check(bar == nil and ball == nil, "disabled options draw no overlays")
 love.graphics.draw, love.graphics.rectangle = oldDraw, oldRectangle
 love.graphics.setColor(1, 1, 1, 1)
 run.release()
+for name, original in pairs(rawInputMethods) do
+  EngineInput[name] = original
+end
+rawset(EngineInput, "__qolMappedGamepadGuard", nil)
+OverworldController.handleInput = originalOverworldHandleInput
 Screens.invalidate()
 T.finish("qol later gen")


### PR DESCRIPTION
## Summary

Per your request, this PR contains only the controller-related changes, rebased onto the current v1.2.2/main. It does not include any Dramatic Shape / Voxel overlay changes.

- ignore duplicate raw joystick callbacks for controllers that already have an SDL gamepad mapping
- preserve the raw fallback for genuinely unmapped handheld controllers
- keep START priority if the same physical press produces both START and SELECT
- add regression coverage for mapped and unmapped controllers

## Root cause

Gen1Recomp 0.1.41+ added raw joystick fallbacks for unmapped handheld controllers. LÖVE also emits raw callbacks for mapped gamepads. On a Nintendo Switch Pro Controller, Plus is standardized START plus raw button 7 (mapped by the fallback to SELECT), while L is raw button 10 (mapped by the fallback to START). Easy Interactions could consume the duplicate SELECT before the base START handler.

## Validation

- `200/200 checks passed (qol later gen)`
- physical Nintendo Switch Pro Controller: Plus remains START and L does not become START
- mapped-pad raw button 7/10 regressions covered
- unmapped joystick fallback remains covered

This supersedes the controller portion of #9. The Voxel/EXP/caught-indicator changes are intentionally excluded because v1.2.2 already contains the maintainer's implementation.

Fixes #8